### PR TITLE
Sleep

### DIFF
--- a/pico/main.c
+++ b/pico/main.c
@@ -161,6 +161,13 @@ void state_handler_set_timer(udpih_device_t* device, uint32_t ms)
 
 int main()
 {
+    gpio_init(PICO_DEFAULT_LED_PIN);
+    gpio_set_dir(PICO_DEFAULT_LED_PIN, GPIO_OUT);
+    gpio_put(PICO_DEFAULT_LED_PIN, 1);
+
+    sleep_ms(8125);
+    gpio_put(PICO_DEFAULT_LED_PIN, 0);
+
     stdio_init_all();
     printf("Wii U UHS exploit\n");
 


### PR DESCRIPTION
This allows to connect the Pico before turning the Wii U on, making it more simple.