### PR TITLE
Add version-aware timer delete helper

### DIFF
--- a/linux/main.c
+++ b/linux/main.c
@@ -2,6 +2,7 @@
 #include <linux/module.h>
 #include <linux/kernel.h>
 #include <linux/init.h>
+#include <linux/version.h>
 
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("GaryOderNichts");
@@ -9,6 +10,15 @@ MODULE_DESCRIPTION("Implements a USB Host Stack exploit for the Wii U");
 MODULE_VERSION("5");
 
 #define EP0_BUF_SIZE 0x10000 // matches UhsDevice's pEp0DmaBuf size
+
+static int udpih_timer_delete(struct timer_list* timer)
+{
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+    return timer_delete(timer);
+#else
+    return del_timer(timer);
+#endif
+}
 
 void udpih_state_change_work_callback(struct work_struct* work)
 {
@@ -187,7 +197,7 @@ void udpih_gadget_disconnect(struct usb_gadget* gadget)
             || device->common_dev.state == STATE_DEVICE2_CONNECTED) {
             device->common_dev.state = STATE_INIT;
             // cannot use the _sync versions here, as this might run in an irq context
-            del_timer(&device->state_timer);
+            udpih_timer_delete(&device->state_timer);
             cancel_work(&device->state_work);
         }
     }
@@ -204,7 +214,7 @@ void udpih_gadget_suspend(struct usb_gadget* gadget)
         // reset device on suspend
         device->common_dev.state = STATE_INIT;
         // cannot use the _sync versions here, as this might run in an irq context
-        del_timer(&device->state_timer);
+        udpih_timer_delete(&device->state_timer);
         cancel_work(&device->state_work);
     }
 }


### PR DESCRIPTION
## Summary

- Add `udpih_timer_delete()` as a small compatibility wrapper for Linux timer deletion.
- Use `timer_delete()` on kernels `>= 6.15.0`, where `del_timer()` is no longer available.
- Fall back to `del_timer()` on older kernels to keep compatibility with existing Linux builds.
- Replace direct `del_timer()` calls in the gadget disconnect/suspend paths with the wrapper.

## Background

The Linux kernel module stopped building after updating to a newer kernel, observed on the latest SteamOS kernel update for Steam Deck. This is not SteamOS-specific: Linux `6.15+` uses `timer_delete()` instead of exposing `del_timer()` as before, so the same build failure can affect other Linux-based targets once they move to newer kernels.

This keeps the module portable across newer and older Linux kernels without changing the gadget state-machine behavior.

## Testing

- Confirmed the module builds again against the Steam Deck `6.16.12-valve24-1-neptune-616` kernel.
- Verified the compatibility wrapper preserves the older-kernel path for kernels before `6.15.0`.
- Confirmed the module loads after enabling the required Steam Deck BIOS USB Dual Role Device configuration from the existing guide.